### PR TITLE
Bump node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,5 +71,5 @@ inputs:
     description: A JSON-based array of structured blocks. Setting this property will override the default blocks.
     required: false
 runs:
-  using: 'node12'
+  using: 'node18'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -71,5 +71,5 @@ inputs:
     description: A JSON-based array of structured blocks. Setting this property will override the default blocks.
     required: false
 runs:
-  using: 'node18'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Our nightly build are failing with the following message

The following actions use node12 which is deprecated and will be forced to run on node16: Sixt/action-slack-message@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
